### PR TITLE
Struct initializer lists: one more case

### DIFF
--- a/regression/TEST
+++ b/regression/TEST
@@ -37,7 +37,7 @@ BUGS="case-label.c one-line-1.c one-line-2.c one-line-3.c \
         one-line-4.c struct-decl.c sizeof-in-while.c line-break-comment.c \
         macro.c enum.c elif.c nested.c wrapped-string.c minus_predecrement.c \
         bug-gnu-33364.c float-constant-suffix.c block-comments.c \
-        no-forced-nl-in-block-init.c"
+        no-forced-nl-in-block-init.c compound-initializers.c"
 
 INDENTSRC="args.c backup.h backup.c dirent_def.h globs.c indent.h \
         indent.c indent_globs.h io.c lexi.c memcpy.c parse.c pr_comment.c \

--- a/regression/input/compound-initializers.c
+++ b/regression/input/compound-initializers.c
@@ -1,0 +1,6 @@
+    *rn = (chrename_t) {
+        .chat_id    = chat_id,
+        .newname    = sl_dup(newname_utf8),
+        .cb         = cb,
+        .udata      = udata,
+    };

--- a/regression/standard/compound-initializers.c
+++ b/regression/standard/compound-initializers.c
@@ -1,0 +1,6 @@
+* rn = (chrename_t) {
+  .chat_id = chat_id,
+  .newname = sl_dup (newname_utf8),
+  .cb = cb,
+  .udata = udata,
+};


### PR DESCRIPTION
Fix formatting for struct assignment, for example:

structname_t *str = malloc(..);
*str = (structname_t) {
   .f = "a",
   .f2 = "b".
}
